### PR TITLE
zerosum: allow cost units under EPSILON_DELTA/2

### DIFF
--- a/beancount_reds_plugins/zerosum/zerosum.py
+++ b/beancount_reds_plugins/zerosum/zerosum.py
@@ -221,6 +221,9 @@ def zerosum(entries, options_map, config):
             if t.date > max_date:
                 return None
             for p in t.postings:
+                if p is posting:
+                    # Don't match with the same exact posting.
+                    continue
                 if (abs(p.units.number + posting.units.number) < EPSILON_DELTA
                     and p.account == zs_account):
                     return (p, t)

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -2,7 +2,7 @@ option "operating_currency" "USD"
 
 plugin "beancount.plugins.auto_accounts"
 
-plugin "plugins.beancount_plugins_redstreet.zerosum.zerosum" "{
+plugin "beancount_reds_plugins.zerosum.zerosum" "{
  'zerosum_accounts' : { 
  'Assets:Zero-Sum-Accounts:Returns-and-Temporary'              : ('', 90),
   },

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -27,10 +27,10 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
   Assets:Zero-Sum-Accounts:Returns-and-Temporary -1.00 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD
 
-2020-06-01 * "Match two lookalike postings in one txn"
+2020-06-01 * "Match two lookalike postings in one txn" ; should not error
   Assets:Zero-Sum-Accounts:Returns-and-Temporary  0.00 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary  0.00 USD
 
-2021-01-01 * "Unmatched"
+2021-01-01 * "Unmatched" ; should not error
   Liabilities:Credit-Cards:Vsia -0.00495 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -27,11 +27,9 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
   Assets:Zero-Sum-Accounts:Returns-and-Temporary -1.00 USD ; this should match...
   Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD ; ...with this
 
-2020-06-01 * "Match two lookalike pairs of postings in one txn"
-  Assets:Zero-Sum-Accounts:Returns-and-Temporary -1.00 USD ; this shouldn't match...
-  Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD
-  Assets:Zero-Sum-Accounts:Returns-and-Temporary -1.00 USD ; ...with this
-  Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD
+2020-06-01 * "Match two lookalike postings in one txn"
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary  0.00 USD
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary  0.00 USD
 
 2021-01-01 * "Unmatched"
   Liabilities:Credit-Cards:Vsia -0.00495 USD

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -23,6 +23,10 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
   Liabilities:Credit-Cards:Vsia  1263.01 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
+2020-01-01 * "Match both postings in one txn"
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary  -1.00 USD
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD
+
 2021-01-31 * "Unmatched"
   Liabilities:Credit-Cards:Vsia  -0.00495 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -24,8 +24,8 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
   Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
 2020-01-01 * "Match both postings in one txn"
-  Assets:Zero-Sum-Accounts:Returns-and-Temporary -1.00 USD ; this should match...
-  Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD ; ...with this
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary -1.00 USD
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD
 
 2020-06-01 * "Match two lookalike postings in one txn"
   Assets:Zero-Sum-Accounts:Returns-and-Temporary  0.00 USD

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -11,7 +11,7 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
 
 
 2015-06-15 * "Expensive furniture"
-  Liabilities:Credit-Cards:Vsia  -2526.02 USD
+  Liabilities:Credit-Cards:Vsia -2526.02 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
 
@@ -24,9 +24,9 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
   Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
 2020-01-01 * "Match both postings in one txn"
-  Assets:Zero-Sum-Accounts:Returns-and-Temporary  -1.00 USD ; this should match...
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary -1.00 USD ; this should match...
   Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD ; ...with this
 
 2021-01-01 * "Unmatched"
-  Liabilities:Credit-Cards:Vsia  -0.00495 USD
+  Liabilities:Credit-Cards:Vsia -0.00495 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -27,6 +27,6 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
   Assets:Zero-Sum-Accounts:Returns-and-Temporary  -1.00 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD
 
-2021-01-31 * "Unmatched"
+2021-01-01 * "Unmatched"
   Liabilities:Credit-Cards:Vsia  -0.00495 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -27,6 +27,12 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
   Assets:Zero-Sum-Accounts:Returns-and-Temporary -1.00 USD ; this should match...
   Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD ; ...with this
 
+2020-06-01 * "Match two lookalike pairs of postings in one txn"
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary -1.00 USD ; this shouldn't match...
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary -1.00 USD ; ...with this
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD
+
 2021-01-01 * "Unmatched"
   Liabilities:Credit-Cards:Vsia -0.00495 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -22,3 +22,7 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
 2015-06-23 * "Expensive furniture Refund"
   Liabilities:Credit-Cards:Vsia  1263.01 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary
+
+2021-01-31 * "Unmatched"
+  Liabilities:Credit-Cards:Vsia  -0.00495 USD
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -24,8 +24,8 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
   Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
 2020-01-01 * "Match both postings in one txn"
-  Assets:Zero-Sum-Accounts:Returns-and-Temporary  -1.00 USD
-  Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary  -1.00 USD ; this should match...
+  Assets:Zero-Sum-Accounts:Returns-and-Temporary  1.00 USD ; ...with this
 
 2021-01-01 * "Unmatched"
   Liabilities:Credit-Cards:Vsia  -0.00495 USD


### PR DESCRIPTION
There is a bug when the cost of a zerosum posting is under half of
`EPSILON_DELTA` (0.0099).  When trying to find a matching posting,
`find_match` looks at the same posting.  If the absolute difference of
the two postings is less than this delta, it says it's a match, and both
postings' account names are changed.  If the two postings refer to the
same thing, we try to rename twice and get a

    ValueError: list.remove(x): x not in list

on

    txn.postings.remove(posting)

Fix this by avoiding looking at the same posting.
