### PR TITLE
zerosum: add config option "tolerance"

### DIFF
--- a/beancount_reds_plugins/zerosum/test_zerosum.py
+++ b/beancount_reds_plugins/zerosum/test_zerosum.py
@@ -8,7 +8,7 @@ from beancount.parser import options
 from beancount import loader
 
 config = """{
- 'zerosum_accounts' : { 
+ 'zerosum_accounts' : {
  'Assets:Zero-Sum-Accounts:Returns-and-Temporary'              : ('', 90),
   },
   'account_name_replace' : ('Zero-Sum-Accounts', 'ZSA-Matched')
@@ -71,11 +71,11 @@ class TestUnrealized(unittest.TestCase):
           Liabilities:Credit-Cards:Visa  -2526.02 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
-        
+
         2015-06-23 * "Expensive furniture Refund"
           Liabilities:Credit-Cards:Visa  1263.01 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
-        
+
         2015-06-23 * "Expensive furniture Refund"
           Liabilities:Credit-Cards:Visa  1263.01 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
@@ -98,7 +98,7 @@ class TestUnrealized(unittest.TestCase):
         2015-06-15 * "Trinket"
           Liabilities:Credit-Cards:Visa  -0.014 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
-        
+
         2015-06-23 * "Trinket refund"
           Liabilities:Credit-Cards:Visa  0.014 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
@@ -121,7 +121,7 @@ class TestUnrealized(unittest.TestCase):
         2015-06-15 * "Trinket"
           Liabilities:Credit-Cards:Visa  -0.004 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
-        
+
         2015-06-23 * "Trinket refund"
           Liabilities:Credit-Cards:Visa  0.004 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary

--- a/beancount_reds_plugins/zerosum/test_zerosum.py
+++ b/beancount_reds_plugins/zerosum/test_zerosum.py
@@ -65,19 +65,19 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_single_rename(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Vsia
+        2015-01-01 open Liabilities:Credit-Cards:Visa
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
         2015-06-15 * "Expensive furniture"
-          Liabilities:Credit-Cards:Vsia  -2526.02 USD
+          Liabilities:Credit-Cards:Visa  -2526.02 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
         
         2015-06-23 * "Expensive furniture Refund"
-          Liabilities:Credit-Cards:Vsia  1263.01 USD
+          Liabilities:Credit-Cards:Visa  1263.01 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
         
         2015-06-23 * "Expensive furniture Refund"
-          Liabilities:Credit-Cards:Vsia  1263.01 USD
+          Liabilities:Credit-Cards:Visa  1263.01 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
         """
         new_entries, _ = zerosum.zerosum(entries, options_map, config)
@@ -93,14 +93,14 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_above_epsilon(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Vsia
+        2015-01-01 open Liabilities:Credit-Cards:Visa
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
         2015-06-15 * "Trinket"
-          Liabilities:Credit-Cards:Vsia  -0.014 USD
+          Liabilities:Credit-Cards:Visa  -0.014 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
         
         2015-06-23 * "Trinket refund"
-          Liabilities:Credit-Cards:Vsia  0.014 USD
+          Liabilities:Credit-Cards:Visa  0.014 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
         """
         new_entries, _ = zerosum.zerosum(entries, options_map, config)
@@ -116,14 +116,14 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_below_epsilon(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Vsia
+        2015-01-01 open Liabilities:Credit-Cards:Visa
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
         2015-06-15 * "Trinket"
-          Liabilities:Credit-Cards:Vsia  -0.004 USD
+          Liabilities:Credit-Cards:Visa  -0.004 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
         
         2015-06-23 * "Trinket refund"
-          Liabilities:Credit-Cards:Vsia  0.004 USD
+          Liabilities:Credit-Cards:Visa  0.004 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
         """
         new_entries, _ = zerosum.zerosum(entries, options_map, config)
@@ -139,7 +139,7 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_lookalike(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Vsia
+        2015-01-01 open Liabilities:Credit-Cards:Visa
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
         2020-06-01 * "Match two lookalike postings in one txn" ; should not error
@@ -159,7 +159,7 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_both_postings_in_one_txn(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Vsia
+        2015-01-01 open Liabilities:Credit-Cards:Visa
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
         2020-01-01 * "Match both postings in one txn"

--- a/beancount_reds_plugins/zerosum/test_zerosum.py
+++ b/beancount_reds_plugins/zerosum/test_zerosum.py
@@ -12,6 +12,7 @@ config = """{
  'Assets:Zero-Sum-Accounts:Returns-and-Temporary'              : ('', 90),
   },
   'account_name_replace' : ('Zero-Sum-Accounts', 'ZSA-Matched'),
+  'tolerance' : 0.0098,
  }"""
 
 def get_entries_with_acc_regexp(entries, regexp):

--- a/beancount_reds_plugins/zerosum/test_zerosum.py
+++ b/beancount_reds_plugins/zerosum/test_zerosum.py
@@ -11,7 +11,7 @@ config = """{
  'zerosum_accounts' : {
  'Assets:Zero-Sum-Accounts:Returns-and-Temporary'              : ('', 90),
   },
-  'account_name_replace' : ('Zero-Sum-Accounts', 'ZSA-Matched')
+  'account_name_replace' : ('Zero-Sum-Accounts', 'ZSA-Matched'),
  }"""
 
 def get_entries_with_acc_regexp(entries, regexp):

--- a/beancount_reds_plugins/zerosum/test_zerosum.py
+++ b/beancount_reds_plugins/zerosum/test_zerosum.py
@@ -91,7 +91,7 @@ class TestUnrealized(unittest.TestCase):
             self.assertEqual('Assets:ZSA-Matched:Returns-and-Temporary', matched[m].postings[p].account)
 
     @loader.load_doc()
-    def test_above_epsilon(self, entries, _, options_map):
+    def test_above_tolerance(self, entries, _, options_map):
         """
         2015-01-01 open Liabilities:Credit-Cards:Visa
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
@@ -114,7 +114,7 @@ class TestUnrealized(unittest.TestCase):
             self.assertEqual('Assets:ZSA-Matched:Returns-and-Temporary', matched[m].postings[p].account)
 
     @loader.load_doc()
-    def test_below_epsilon(self, entries, _, options_map):
+    def test_below_tolerance(self, entries, _, options_map):
         """
         2015-01-01 open Liabilities:Credit-Cards:Visa
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
@@ -177,12 +177,12 @@ class TestUnrealized(unittest.TestCase):
             self.assertEqual('Assets:ZSA-Matched:Returns-and-Temporary', matched[m].postings[p].account)
 
     @loader.load_doc()
-    def test_two_matched_below_epsilon(self, entries, _, options_map):
+    def test_two_matched_below_tolerance(self, entries, _, options_map):
         """
         2015-01-01 open Liabilities:Credit-Cards:Visa
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
-        2021-01-01 * "(two unmatched postings summing under epsilon)"
+        2021-01-01 * "(two unmatched postings summing under tolerance)"
           Assets:Zero-Sum-Accounts:Returns-and-Temporary -0.001 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary -0.002 USD
           Liabilities:Credit-Cards:Visa
@@ -197,12 +197,12 @@ class TestUnrealized(unittest.TestCase):
         self.assertEqual(2, matched_postings)
 
     @loader.load_doc()
-    def test_two_unmatched_above_epsilon(self, entries, _, options_map):
+    def test_two_unmatched_above_tolerance(self, entries, _, options_map):
         """
         2015-01-01 open Liabilities:Credit-Cards:Visa
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
-        2021-01-01 * "(two unmatched postings summing under epsilon)"
+        2021-01-01 * "(two unmatched postings summing under tolerance)"
           Assets:Zero-Sum-Accounts:Returns-and-Temporary -0.00494 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary -0.00496 USD
           Liabilities:Credit-Cards:Visa

--- a/beancount_reds_plugins/zerosum/test_zerosum.py
+++ b/beancount_reds_plugins/zerosum/test_zerosum.py
@@ -66,19 +66,19 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_single_rename(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Visa
+        2015-01-01 open Liabilities:Credit-Cards:Green
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
         2015-06-15 * "Expensive furniture"
-          Liabilities:Credit-Cards:Visa  -2526.02 USD
+          Liabilities:Credit-Cards:Green  -2526.02 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
 
         2015-06-23 * "Expensive furniture Refund"
-          Liabilities:Credit-Cards:Visa  1263.01 USD
+          Liabilities:Credit-Cards:Green  1263.01 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
         2015-06-23 * "Expensive furniture Refund"
-          Liabilities:Credit-Cards:Visa  1263.01 USD
+          Liabilities:Credit-Cards:Green  1263.01 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
         """
         new_entries, _ = zerosum.zerosum(entries, options_map, config)
@@ -94,14 +94,14 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_above_tolerance(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Visa
+        2015-01-01 open Liabilities:Credit-Cards:Green
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
         2015-06-15 * "Trinket"
-          Liabilities:Credit-Cards:Visa  -0.014 USD
+          Liabilities:Credit-Cards:Green  -0.014 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
         2015-06-23 * "Trinket refund"
-          Liabilities:Credit-Cards:Visa  0.014 USD
+          Liabilities:Credit-Cards:Green  0.014 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
         """
         new_entries, _ = zerosum.zerosum(entries, options_map, config)
@@ -117,14 +117,14 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_below_tolerance(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Visa
+        2015-01-01 open Liabilities:Credit-Cards:Green
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
         2015-06-15 * "Trinket"
-          Liabilities:Credit-Cards:Visa  -0.004 USD
+          Liabilities:Credit-Cards:Green  -0.004 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
         2015-06-23 * "Trinket refund"
-          Liabilities:Credit-Cards:Visa  0.004 USD
+          Liabilities:Credit-Cards:Green  0.004 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary
         """
         new_entries, _ = zerosum.zerosum(entries, options_map, config)
@@ -140,7 +140,7 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_lookalike(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Visa
+        2015-01-01 open Liabilities:Credit-Cards:Green
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
         2020-06-01 * "Match two lookalike postings in one txn" ; should not error
@@ -160,7 +160,7 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_both_postings_in_one_txn(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Visa
+        2015-01-01 open Liabilities:Credit-Cards:Green
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
         2020-01-01 * "Match both postings in one txn"
@@ -180,13 +180,13 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_two_matched_below_tolerance(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Visa
+        2015-01-01 open Liabilities:Credit-Cards:Green
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
         2021-01-01 * "(two unmatched postings summing under tolerance)"
           Assets:Zero-Sum-Accounts:Returns-and-Temporary -0.001 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary -0.002 USD
-          Liabilities:Credit-Cards:Visa
+          Liabilities:Credit-Cards:Green
         """
         new_entries, _ = zerosum.zerosum(entries, options_map, config)
 
@@ -200,13 +200,13 @@ class TestUnrealized(unittest.TestCase):
     @loader.load_doc()
     def test_two_unmatched_above_tolerance(self, entries, _, options_map):
         """
-        2015-01-01 open Liabilities:Credit-Cards:Visa
+        2015-01-01 open Liabilities:Credit-Cards:Green
         2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
         2021-01-01 * "(two unmatched postings summing under tolerance)"
           Assets:Zero-Sum-Accounts:Returns-and-Temporary -0.00494 USD
           Assets:Zero-Sum-Accounts:Returns-and-Temporary -0.00496 USD
-          Liabilities:Credit-Cards:Visa
+          Liabilities:Credit-Cards:Green
         """
         new_entries, _ = zerosum.zerosum(entries, options_map, config)
 

--- a/beancount_reds_plugins/zerosum/zerosum.py
+++ b/beancount_reds_plugins/zerosum/zerosum.py
@@ -173,7 +173,7 @@ from beancount.core import flags
 from beancount.core import getters
 
 DEBUG = 0
-TOLERANCE = 0.0099
+DEFAULT_TOLERANCE = 0.0099
 
 __plugins__ = ('zerosum', 'flag_unmatched',)
 
@@ -240,7 +240,7 @@ def zerosum(entries, options_map, config):
     config_obj = literal_eval(config) #TODO: error check
     zs_accounts_list = config_obj.pop('zerosum_accounts', {})
     (account_name_from, account_name_to) = config_obj.pop('account_name_replace', ('', ''))
-    tolerance = config_obj.pop('tolerance', TOLERANCE)
+    tolerance = config_obj.pop('tolerance', DEFAULT_TOLERANCE)
 
     new_accounts = set()
     zerosum_postings_count = 0

--- a/beancount_reds_plugins/zerosum/zerosum.py
+++ b/beancount_reds_plugins/zerosum/zerosum.py
@@ -173,6 +173,7 @@ from beancount.core import flags
 from beancount.core import getters
 
 DEBUG = 0
+EPSILON_DELTA = 0.0099
 
 __plugins__ = ('zerosum', 'flag_unmatched',)
 
@@ -202,6 +203,8 @@ def zerosum(entries, options_map, config):
 
       - 'account_name_replace': tuple of two entries. See above
 
+      - 'epsilon_delta': the maximum cost difference between two matching postings
+
       - 'flag_unmatched': bool to control whether to flag unmatched
         transactions as warnings (default off)
 
@@ -224,7 +227,7 @@ def zerosum(entries, options_map, config):
                 if p is posting:
                     # Don't match with the same exact posting.
                     continue
-                if (abs(p.units.number + posting.units.number) < EPSILON_DELTA
+                if (abs(p.units.number + posting.units.number) < epsilon_delta
                     and p.account == zs_account):
                     return (p, t)
         return None
@@ -237,11 +240,11 @@ def zerosum(entries, options_map, config):
     config_obj = literal_eval(config) #TODO: error check
     zs_accounts_list = config_obj.pop('zerosum_accounts', {})
     (account_name_from, account_name_to) = config_obj.pop('account_name_replace', ('', ''))
+    epsilon_delta = config_obj.pop('epsilon_delta', EPSILON_DELTA)
 
     new_accounts = set()
     zerosum_postings_count = 0
     match_count = 0
-    EPSILON_DELTA = 0.0099
 
     # Build zerosum_txns_all for all zs_accounts, so we iterate through entries only once (for performance)
     zerosum_txns_all = defaultdict(list)

--- a/beancount_reds_plugins/zerosum/zerosum.py
+++ b/beancount_reds_plugins/zerosum/zerosum.py
@@ -173,7 +173,7 @@ from beancount.core import flags
 from beancount.core import getters
 
 DEBUG = 0
-EPSILON_DELTA = 0.0099
+TOLERANCE = 0.0099
 
 __plugins__ = ('zerosum', 'flag_unmatched',)
 
@@ -203,7 +203,7 @@ def zerosum(entries, options_map, config):
 
       - 'account_name_replace': tuple of two entries. See above
 
-      - 'epsilon_delta': the maximum cost difference between two matching postings
+      - 'tolerance': the maximum cost difference between two matching postings
 
       - 'flag_unmatched': bool to control whether to flag unmatched
         transactions as warnings (default off)
@@ -227,7 +227,7 @@ def zerosum(entries, options_map, config):
                 if p is posting:
                     # Don't match with the same exact posting.
                     continue
-                if (abs(p.units.number + posting.units.number) < epsilon_delta
+                if (abs(p.units.number + posting.units.number) < tolerance
                     and p.account == zs_account):
                     return (p, t)
         return None
@@ -240,7 +240,7 @@ def zerosum(entries, options_map, config):
     config_obj = literal_eval(config) #TODO: error check
     zs_accounts_list = config_obj.pop('zerosum_accounts', {})
     (account_name_from, account_name_to) = config_obj.pop('account_name_replace', ('', ''))
-    epsilon_delta = config_obj.pop('epsilon_delta', EPSILON_DELTA)
+    tolerance = config_obj.pop('tolerance', TOLERANCE)
 
     new_accounts = set()
     zerosum_postings_count = 0

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -11,16 +11,16 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
 
 
 2015-06-15 * "Expensive furniture"
-  Liabilities:Credit-Cards:Vsia -2526.02 USD
+  Liabilities:Credit-Cards:Visa -2526.02 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
 
 2015-06-23 * "Expensive furniture Refund"
-  Liabilities:Credit-Cards:Vsia  1263.01 USD
+  Liabilities:Credit-Cards:Visa  1263.01 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
 2015-06-23 * "Expensive furniture Refund"
-  Liabilities:Credit-Cards:Vsia  1263.01 USD
+  Liabilities:Credit-Cards:Visa  1263.01 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
 2020-01-01 * "Match both postings in one txn"
@@ -32,5 +32,5 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
   Assets:Zero-Sum-Accounts:Returns-and-Temporary  0.00 USD
 
 2021-01-01 * "Unmatched" ; should not error
-  Liabilities:Credit-Cards:Vsia -0.00495 USD
+  Liabilities:Credit-Cards:Visa -0.00495 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -3,7 +3,7 @@ option "operating_currency" "USD"
 plugin "beancount.plugins.auto_accounts"
 
 plugin "beancount_reds_plugins.zerosum.zerosum" "{
- 'zerosum_accounts' : { 
+ 'zerosum_accounts' : {
  'Assets:Zero-Sum-Accounts:Returns-and-Temporary'              : ('', 90),
   },
   'account_name_replace' : ('Zero-Sum-Accounts', 'ZSA-Matched')

--- a/beancount_reds_plugins/zerosum/zs_test.beancount
+++ b/beancount_reds_plugins/zerosum/zs_test.beancount
@@ -11,16 +11,16 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
 
 
 2015-06-15 * "Expensive furniture"
-  Liabilities:Credit-Cards:Visa -2526.02 USD
+  Liabilities:Credit-Cards:Green -2526.02 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
 
 2015-06-23 * "Expensive furniture Refund"
-  Liabilities:Credit-Cards:Visa  1263.01 USD
+  Liabilities:Credit-Cards:Green  1263.01 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
 2015-06-23 * "Expensive furniture Refund"
-  Liabilities:Credit-Cards:Visa  1263.01 USD
+  Liabilities:Credit-Cards:Green  1263.01 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary
 
 2020-01-01 * "Match both postings in one txn"
@@ -32,5 +32,5 @@ plugin "beancount_reds_plugins.zerosum.zerosum" "{
   Assets:Zero-Sum-Accounts:Returns-and-Temporary  0.00 USD
 
 2021-01-01 * "Unmatched" ; should not error
-  Liabilities:Credit-Cards:Visa -0.00495 USD
+  Liabilities:Credit-Cards:Green -0.00495 USD
   Assets:Zero-Sum-Accounts:Returns-and-Temporary


### PR DESCRIPTION
Zerosum postings with currencies involving small units may
unintentionally be matched because their sum is under "epsilon delta".
First, rename it to "tolerance" to match how beancount calls it for the
balance directive.  Second, add a new global config option "tolerance"
so that the user may lower it when working with currencies of small
units.

It would be nice if "tolerance" were built into `Commodity` objects in
beancount core.  If that happens, the zerosum plugin can go off that.
If that doesn't happen, the zerosum plugin can make "tolerance" a
per-zsa-account option.  For now, having it global is probably fine.