### PR TITLE
rename_accounts: Support renaming within all directives, not just Transaction

### DIFF
--- a/beancount_reds_plugins/rename_accounts/rename_accounts.py
+++ b/beancount_reds_plugins/rename_accounts/rename_accounts.py
@@ -3,7 +3,6 @@
 import time
 from ast import literal_eval
 from beancount.core import data
-from beancount_reds_plugins.common import common
 
 DEBUG = 0
 __plugins__ = ('rename_accounts',)
@@ -25,7 +24,6 @@ def rename_accounts(entries, options_map, config):
 
     start_time = time.time()
     rename_count = 0
-    new_accounts = []
     new_entries = []
     errors = []
 


### PR DESCRIPTION
`rename_accounts` currently only applies to transactions. This causes several problems:

1. After renaming, balance assertions are no longer valid because they still refer to the original account name.
2. The original accounts are still opened, cluttering the chart of accounts.
3. Notes and documents remain attached to the original account name rather than the new account name.

This PR fixes these problems by generalizing `rename_accounts` to apply to all directives that contain account names, not just transactions.