### PR TITLE
rename_accounts: Copy only renamed directives for performance

### DIFF
--- a/beancount_reds_plugins/rename_accounts/rename_accounts.py
+++ b/beancount_reds_plugins/rename_accounts/rename_accounts.py
@@ -8,7 +8,7 @@ DEBUG = 0
 __plugins__ = ('rename_accounts',)
 
 
-def rename_accounts(entries, options_map, config):
+def rename_accounts(entries, options_map, config):  # noqa: C901
     """Insert entries for unmatched transactions in zero-sum accounts.
 
     Args:

--- a/beancount_reds_plugins/rename_accounts/rename_accounts.py
+++ b/beancount_reds_plugins/rename_accounts/rename_accounts.py
@@ -30,40 +30,45 @@ def rename_accounts(entries, options_map, config):  # noqa: C901
     renames = literal_eval(config)
 
     def rename_account(account):
-        """Apply 'renames' to 'account' and return the resulting account name."""
+        """Apply 'renames' to 'account'.
+
+        Return the resulting account name and whether or not it was renamed.
+
+        """
         nonlocal rename_count
+        was_renamed = False
         for r in renames:
             if r in account:
                 account = account.replace(r, renames[r])
                 rename_count += 1
-        return account
+                was_renamed = True
+        return account, was_renamed
 
     def rename_account_in_entry(entry, account_attr='account'):
+        """Apply 'renames' to 'getattr(entry, account_attr)'.
+
+        Return the resulting entry and whether or not it was renamed.
+
+        """
         old_account = getattr(entry, account_attr)
-        new_account = rename_account(old_account)
-        if new_account is not old_account:
-            return entry._replace(**{account_attr: new_account})
-        else:
-            return entry
+        new_account, was_renamed = rename_account(old_account)
+        new_entry = entry._replace(**{account_attr: new_account}) if was_renamed else entry
+        return new_entry, was_renamed
 
     for entry in entries:
         if isinstance(entry, data.Transaction):
             new_postings = []
             any_posting_changed = False
             for posting in entry.postings:
-                new_posting = rename_account_in_entry(posting)
-                if new_posting is not posting:
-                    any_posting_changed = True
+                new_posting, was_renamed = rename_account_in_entry(posting)
+                any_posting_changed = any_posting_changed or was_renamed
                 new_postings.append(new_posting)
-            if any_posting_changed:
-                new_entry = entry._replace(postings=new_postings)
-            else:
-                new_entry = entry
+            new_entry = entry._replace(postings=new_postings) if any_posting_changed else entry
         elif isinstance(entry, data.Pad):
-            new_entry = rename_account_in_entry(entry, 'account')
-            new_entry = rename_account_in_entry(new_entry, 'source_account')
+            new_entry, _ = rename_account_in_entry(entry, 'account')
+            new_entry, _ = rename_account_in_entry(new_entry, 'source_account')
         elif hasattr(entry, 'account'):
-            new_entry = rename_account_in_entry(entry)
+            new_entry, _ = rename_account_in_entry(entry)
         else:
             new_entry = entry
 


### PR DESCRIPTION
https://github.com/redstreet/beancount_reds_plugins/pull/17 caused the `rename_accounts` plugin to copy all postings within all transactions, even if they were not renamed. This harmed performance. On my ledger with 10,000 transactions, with a rename that affects 8 postings, it increased the runtime from 15.2 ms to 133.9 ms.

This PR fixes the performance regression by copying postings and entries only if they were renamed. This brings the runtime back down to 16.0 ms.