### PR TITLE
feat(rename_accounts): accept regexes for renames

### DIFF
--- a/beancount_reds_plugins/rename_accounts/README.md
+++ b/beancount_reds_plugins/rename_accounts/README.md
@@ -55,3 +55,19 @@ example above.
 
 Account opening entries will be added to Beancount automatically if needed (eg: for
 `Income:Taxes:Federal` above).
+
+The strings on the left may be regular expressions, in which case the strings on
+the right may contain backreferences to capturing groups. For example, the
+following configuration will rename accounts like
+`Income:Brokerage:CapitalGains:VTI` to `Assets:Brokerage:CapitalGains:VTI`. This
+prevents dividends, realized capital gains, and fees from affecting the account
+balance of `Assets:Brokerage`, revealing the net inflows into the
+`Assets:Brokerage` account:
+
+```python
+plugin "beancount_reds_plugins.rename_accounts.rename_accounts" "{
+  'Income(:.+)?:Dividends(:.+)?' : 'Assets\\\\1:Dividends\\\\2',
+  'Income(:.+)?:CapitalGains(:.+)?' : 'Assets\\\\1:CapitalGains\\\\2',
+  'Expenses(:.+)?:Fees(:.+)?' : 'Assets\\\\1:Fees\\\\2',
+}"
+```

--- a/beancount_reds_plugins/rename_accounts/TODO.txt
+++ b/beancount_reds_plugins/rename_accounts/TODO.txt
@@ -1,2 +1,1 @@
-- accept regexes for renames
 

--- a/beancount_reds_plugins/rename_accounts/rename_accounts.py
+++ b/beancount_reds_plugins/rename_accounts/rename_accounts.py
@@ -1,5 +1,6 @@
 """See accompanying README.md"""
 
+import re
 import time
 from ast import literal_eval
 from beancount.core import data
@@ -27,7 +28,8 @@ def rename_accounts(entries, options_map, config):  # noqa: C901
     new_entries = []
     errors = []
 
-    renames = literal_eval(config)
+    renames = dict([(re.compile(pattern), replacement)
+                    for pattern, replacement in literal_eval(config).items()])
 
     def rename_account(account):
         """Apply 'renames' to 'account'.
@@ -37,9 +39,9 @@ def rename_accounts(entries, options_map, config):  # noqa: C901
         """
         nonlocal rename_count
         was_renamed = False
-        for r in renames:
-            if r in account:
-                account = account.replace(r, renames[r])
+        for pattern, replacement in renames.items():
+            account, num_replacements = pattern.subn(replacement, account)
+            if num_replacements > 0:
                 rename_count += 1
                 was_renamed = True
         return account, was_renamed


### PR DESCRIPTION
This PR adds support for regex account renames with capturing groups and backreferences.

One use case is calculating the net inflows into an account, excluding internal flows such as dividends, realized capital gains, and fees. Regexes can be used to move these internal flows into `Assets:`, preventing them from affecting the account balance.

Unfortunately, this does affect performance even for non-regex renames. On my ledger with 10,000 transactions, with a rename that affects 165 postings, it increases the runtime from 26 ms to 35 ms. If we want to avoid this regression, we could try to detect non-regex renames and use a fast path for those, or we could add a separate user-facing configuration for regex renames.