### PR TITLE
fix: ensure independence of metadata / linking config

### DIFF
--- a/beancount_reds_plugins/zerosum/test_zerosum.py
+++ b/beancount_reds_plugins/zerosum/test_zerosum.py
@@ -395,3 +395,87 @@ class TestUnrealized(unittest.TestCase):
             any(link.startswith("ZSM") for link in (matched["Pay stub"].links & matched["401k statement"].links)))
         self.assertFalse(
             any(link.startswith("ZSM") for link in (matched["Bank account"].links & matched["401k statement"].links)))
+
+
+    @loader.load_doc()
+    def test_metadata_independent_from_linking(self, entries, _, options_map):
+        """
+        2023-01-01 open Income:Salary
+        2023-01-01 open Assets:Bank:Checkings
+        2023-01-01 open Assets:Zero-Sum-Accounts:Checkings
+        2023-01-01 open Assets:Brokerage:401k
+        2023-01-01 open Assets:Zero-Sum-Accounts:401k
+
+        2024-02-15 * "Pay stub"
+          Income:Salary                                -1100.06 USD
+          Assets:Zero-Sum-Accounts:Checkings             999.47 USD
+          Assets:Zero-Sum-Accounts:401k                  100.59 USD
+
+        2024-02-16 * "Bank account"
+          Assets:Bank:Checkings                          999.47 USD
+          Assets:Zero-Sum-Accounts:Checkings
+
+        2024-02-16 * "401k statement"
+          Assets:Brokerage:401k                          100.59 USD
+          Assets:Zero-Sum-Accounts:401k
+        """
+        new_entries, _ = zerosum.zerosum(
+            entries, options_map,
+            config[:-2] + """'match_metadata': True,\n'match_metadata_name': 'MATCH',\n'link_transactions': False,\n'link_prefix': 'ZSM'\n}""")
+
+        matched = dict(
+            [(m.narration, m) for m in
+             get_entries_with_acc_regexp(new_entries, ':ZSA-Matched')])
+
+        self.assertEqual(3, len(matched))
+        self.assertEqual(matched["Pay stub"].postings[1].meta['MATCH'],
+                         matched["Bank account"].postings[1].meta['MATCH'])
+        self.assertEqual(matched["Pay stub"].postings[2].meta['MATCH'],
+                         matched["401k statement"].postings[1].meta['MATCH'])
+
+        for _, m in matched.items():
+            self.assertFalse(any(link.startswith("ZSM") for link in m.links))
+
+
+    @loader.load_doc()
+    def test_linking_independent_from_metadata(self, entries, _, options_map):
+        """
+        2023-01-01 open Income:Salary
+        2023-01-01 open Assets:Bank:Checkings
+        2023-01-01 open Assets:Zero-Sum-Accounts:Checkings
+        2023-01-01 open Assets:Brokerage:401k
+        2023-01-01 open Assets:Zero-Sum-Accounts:401k
+
+        2024-02-15 * "Pay stub"
+          Income:Salary                                -1100.06 USD
+          Assets:Zero-Sum-Accounts:Checkings             999.47 USD
+          Assets:Zero-Sum-Accounts:401k                  100.59 USD
+
+        2024-02-16 * "Bank account"
+          Assets:Bank:Checkings                          999.47 USD
+          Assets:Zero-Sum-Accounts:Checkings
+
+        2024-02-16 * "401k statement"
+          Assets:Brokerage:401k                          100.59 USD
+          Assets:Zero-Sum-Accounts:401k
+        """
+        new_entries, _ = zerosum.zerosum(
+            entries, options_map,
+            config[:-2] + """'match_metadata': False,\n'match_metadata_name': 'MATCH',\n'link_transactions': True,\n'link_prefix': 'ZSM'\n}""")
+
+
+        matched = dict(
+            [(m.narration, m) for m in
+             get_entries_with_acc_regexp(new_entries, ':ZSA-Matched')])
+
+        self.assertEqual(3, len(matched))
+        for _, m in matched.items():
+            for p in m.postings:
+                self.assertTrue('MATCH' not in p.meta)
+
+        self.assertTrue(
+            any(link.startswith("ZSM") for link in (matched["Pay stub"].links & matched["Bank account"].links)))
+        self.assertTrue(
+            any(link.startswith("ZSM") for link in (matched["Pay stub"].links & matched["401k statement"].links)))
+        self.assertFalse(
+            any(link.startswith("ZSM") for link in (matched["Bank account"].links & matched["401k statement"].links)))

--- a/beancount_reds_plugins/zerosum/test_zerosum.py
+++ b/beancount_reds_plugins/zerosum/test_zerosum.py
@@ -396,7 +396,6 @@ class TestUnrealized(unittest.TestCase):
         self.assertFalse(
             any(link.startswith("ZSM") for link in (matched["Bank account"].links & matched["401k statement"].links)))
 
-
     @loader.load_doc()
     def test_metadata_independent_from_linking(self, entries, _, options_map):
         """
@@ -421,7 +420,8 @@ class TestUnrealized(unittest.TestCase):
         """
         new_entries, _ = zerosum.zerosum(
             entries, options_map,
-            config[:-2] + """'match_metadata': True,\n'match_metadata_name': 'MATCH',\n'link_transactions': False,\n'link_prefix': 'ZSM'\n}""")
+            config[:-2] + """'match_metadata': True,\n'match_metadata_name': 'MATCH',\n
+            'link_transactions': False,\n'link_prefix': 'ZSM'\n}""")
 
         matched = dict(
             [(m.narration, m) for m in
@@ -435,7 +435,6 @@ class TestUnrealized(unittest.TestCase):
 
         for _, m in matched.items():
             self.assertFalse(any(link.startswith("ZSM") for link in m.links))
-
 
     @loader.load_doc()
     def test_linking_independent_from_metadata(self, entries, _, options_map):
@@ -461,8 +460,8 @@ class TestUnrealized(unittest.TestCase):
         """
         new_entries, _ = zerosum.zerosum(
             entries, options_map,
-            config[:-2] + """'match_metadata': False,\n'match_metadata_name': 'MATCH',\n'link_transactions': True,\n'link_prefix': 'ZSM'\n}""")
-
+            config[:-2] + """'match_metadata': False,\n'match_metadata_name': 'MATCH',\n
+            'link_transactions': True,\n'link_prefix': 'ZSM'\n}""")
 
         matched = dict(
             [(m.narration, m) for m in

--- a/beancount_reds_plugins/zerosum/zerosum.py
+++ b/beancount_reds_plugins/zerosum/zerosum.py
@@ -190,6 +190,7 @@ def account_replace(txn, posting, new_account):
     txn.postings.remove(posting)
     txn.postings.append(new_posting)
 
+
 def metadata_update(txn, posting, match_id, matching_id_string):
     if match_id and matching_id_string:
         if posting.meta:
@@ -197,6 +198,7 @@ def metadata_update(txn, posting, match_id, matching_id_string):
             posting.meta.update({matching_id_string: match_id})
         else:
             posting.meta = {matching_id_string: match_id}
+
 
 def transaction_update(txn, match_id, link_prefix):
     if match_id and link_prefix:


### PR DESCRIPTION
I realized I made a mistake in #26's logic where adding metadata would happen if `match_metadata` was False, `match_metadata_name` was directly set, and `link_transactions` was True. This PR fixes that logic and adds a test to ensure that the two sets of options don't accidentally enable each other.