### PR TITLE
Fix link collisions in and harmonize option syntax (effective_date / zerosum)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Editor
+*~
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/beancount_reds_plugins/common/common.py
+++ b/beancount_reds_plugins/common/common.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """Common code for beancount_reds_plugins"""
 
+from ast import literal_eval
+import sys
+
 from beancount.core import data
 from beancount.core import getters
 
+PREFIX_LEN = 2
 
-def create_open_directives(new_accounts, entries, meta_desc='<beancount_reds_plugins_common>'):
+
+def create_open_directives(new_accounts, entries,
+                           meta_desc='<beancount_reds_plugins_common>'):
     """Create open entries that don't already exist"""
     if not entries:
         return []
@@ -20,3 +26,51 @@ def create_open_directives(new_accounts, entries, meta_desc='<beancount_reds_plu
             open_entry = data.Open(meta, earliest_date, account_, None, None)
             new_open_entries.append(open_entry)
     return new_open_entries
+
+
+def parse_config(*, defaults, config, warn_params=[], warn_name=""):
+    config_obj = literal_eval(config) if config else {}
+
+    for param in warn_params:
+        if param not in config_obj:
+            print(f"{warn_name}: Using default {param}", file=sys.stderr)
+
+    parsed = defaults | config_obj
+    return parsed
+
+
+class FormattedUIDs():
+    def __init__(self, base, zfill=0, prefix='', date_format=''):
+        self.prefix = prefix
+        self.base = int(base)
+        self.date_format = date_format
+        self.zfill = int(zfill)
+        self.counters = {}
+
+    def format(self, x):
+        if self.base == 8:
+            stripped = oct(x)[PREFIX_LEN:]
+        elif self.base == 10:
+            stripped = str(x)
+        elif self.base == 16:
+            stripped = hex(x)[PREFIX_LEN:]
+        else:
+            raise ValueError(f"Unsupported base: {self.base}")
+
+        filled = stripped.zfill(self.zfill)
+        return filled
+
+    def counter(self, key=''):
+        count = self.counters.get(key, 0)
+        self.counters[key] = count + 1
+        return count
+
+    def get(self, entry_date=None):
+        date_str = entry_date.strftime(self.date_format) if entry_date else ''
+        # The date format may be set to only a year or just an empty string,
+        # so, to guarantee uniqueness, the counters must be keyed by date_str,
+        # not the date value.
+        count = self.counter(date_str)
+        seq = self.format(count)
+        link = self.prefix + date_str + seq
+        return link

--- a/beancount_reds_plugins/effective_date/README.md
+++ b/beancount_reds_plugins/effective_date/README.md
@@ -72,9 +72,9 @@ The plugin allows for postings to occur on multiple different dates. For example
 - an `original_date` metadata is inserted into newly created transactions
 - the `effective_date` per-posting metadata is left untouched. This way, the original
   and new entries both have pointers back to each other
-- a beancount link links the transactions set. It's human readable: ^edate-141215-xlu
+- a beancount link links the transactions set. It's human readable: ^edate-141215-9a7
   means the original transaction was on 2014-12-15
 
-See examples.bc for more examples, and for how to configure the plugin with your choice
-of holding accounts.
-
+See `examples.bc` for more examples, and for how to configure the plugin with your choice
+of holding accounts and see `DEFAULT_FORMATS` in `effective_date.py` for how to configure
+the link format.

--- a/beancount_reds_plugins/effective_date/effective_date.py
+++ b/beancount_reds_plugins/effective_date/effective_date.py
@@ -1,14 +1,13 @@
 """Beancount plugin to implement per-posting effective dates. See README.md for more."""
 
-from ast import literal_eval
 import copy
 import datetime
-import random
-import string
-import sys
 import time
 from beancount.core import data
 from beancount_reds_plugins.common import common
+from beancount_reds_plugins.effective_date.legacy_effective_date_transaction \
+    import effective_date_transaction
+
 
 DEBUG = 0
 
@@ -16,7 +15,17 @@ __plugins__ = ['effective_date']
 # to enable the older transaction-level hacky plugin, now renamed to effective_date_transaction
 # __plugins__ = ['effective_date', 'effective_date_transaction']
 
-LINK_FORMAT = 'edate-{date}-{random}'
+
+DEFAULTS = {
+    'link_base': 16,
+    'link_zfill': 0,
+    'link_prefix': 'edate-',
+    'date_format': '%y%m%d-',
+    'holding_accts': {
+        'Expenses': {'earlier': 'Liabilities:Hold:Expenses', 'later': 'Assets:Hold:Expenses'},
+        'Income':   {'earlier': 'Assets:Hold:Income', 'later': 'Liabilities:Hold:Income'},
+    }
+}
 
 
 def has_valid_effective_date(posting):
@@ -44,20 +53,6 @@ def create_new_effective_date_entry(entry, date, hold_posting, original_posting)
     return effective_date_entry
 
 
-def build_config(config):
-    holding_accts = {}
-    if config:
-        holding_accts = literal_eval(config)
-    if not holding_accts:
-        if DEBUG:
-            print("effective_date: Using default config", file=sys.stderr)
-        holding_accts = {
-                'Expenses': {'earlier': 'Liabilities:Hold:Expenses', 'later': 'Assets:Hold:Expenses'},
-                'Income':   {'earlier': 'Assets:Hold:Income', 'later': 'Liabilities:Hold:Income'},
-                }
-    return holding_accts
-
-
 def effective_date(entries, options_map, config):
     """Effective dates
 
@@ -73,8 +68,14 @@ def effective_date(entries, options_map, config):
     """
     start_time = time.time()
     errors = []
-    holding_accts = build_config(config)
-
+    if DEBUG:
+        warn_args = {'warn_params': ['holding_accts'], 'warn_name': 'effective_date'}
+    else:
+        warn_args = {}
+    parsed_cfg = common.parse_config(defaults=DEFAULTS, config=config, **warn_args)
+    link_maker = common.FormattedUIDs(
+        parsed_cfg['link_base'], parsed_cfg['link_zfill'],
+        parsed_cfg['link_prefix'], parsed_cfg['date_format'])
     interesting_entries = []
     filtered_entries = []
     new_accounts = set()
@@ -94,9 +95,7 @@ def effective_date(entries, options_map, config):
     # entries, and thus links each set of effective date entries
     interesting_entries_linked = []
     for entry in interesting_entries:
-        rand_string = ''.join(random.choice(string.ascii_lowercase) for i in range(3))
-        date = str(entry.date).replace('-', '')[2:]
-        link = LINK_FORMAT.format(date=str(date), random=rand_string)
+        link = link_maker.get(entry.date)
         new_entry = entry._replace(links=(entry.links or set()) | set([link]))
         interesting_entries_linked.append(new_entry)
 
@@ -108,14 +107,14 @@ def effective_date(entries, options_map, config):
                 modified_entry_postings += [posting]
             else:
                 found_acct = ''
-                for acct in holding_accts:
+                for acct in parsed_cfg['holding_accts']:
                     if posting.account.startswith(acct):
                         found_acct = acct
 
                 # find earlier or later (is this necessary?)
-                holding_account = holding_accts[found_acct]['earlier']
+                holding_account = parsed_cfg['holding_accts'][found_acct]['earlier']
                 if posting.meta['effective_date'] > entry.date:
-                    holding_account = holding_accts[found_acct]['later']
+                    holding_account = parsed_cfg['holding_accts'][found_acct]['later']
 
                 # Replace posting in original entry with holding account
                 new_posting = posting._replace(account=posting.account.replace(found_acct, holding_account))
@@ -143,156 +142,6 @@ def effective_date(entries, options_map, config):
     retval = new_open_entries + new_entries + filtered_entries
     return retval, errors
 
-
-def effective_date_transaction(entries, options_map, config):
-    """Effective dates
-
-    Changes this:
-
-    ------(
-    2014-02-01 "Estimated taxes for 2013"
-      effective_date: 2013-12-31
-      Liabilities:Mastercard    -2000 USD
-      Expenses:Taxes:Federal  2000 USD
-    )------
-
-    into this:
-    ------(
-    2014-02-01 "Estimated taxes for 2013"
-      Liabilities:Mastercard     -2000 USD
-      Liabilities:Hold:Taxes:Federal 2000 USD
-
-    2013-12-31 "Estimated taxes for 2013"
-      Liabilities:Hold:Taxes:Federal    -2000 USD
-      Expenses:Taxes:Federal    2000 USD
-    )------
-
-
-    # Example 2: realizing income earlier (eg: for taxes, accounting, etc.):
-    ------(
-    2017-01-03 "Paycheck"
-      effective_date: 2016-12-31
-      Income:Employment    -2000 USD
-      Assets:Bank  2000 USD
-    )------
-
-    into this:
-    ------(
-    2016-12-31 "Paycheck"
-      Income:Employment    -2000 USD
-      Assets:Hold:Income:Employment    2000 USD
-
-    2014-02-01 "Paycheck"
-      Assets:Hold:Income:Employment    -2000 USD
-      Assets:Bank  2000 USD
-    )------
-
-
-    Args:
-      entries: a list of entry instances
-      options_map: a dict of options parsed from the file
-      config: A configuration string, which is intended to be a Python dict
-        mapping match-accounts to a pair of (negative-account, position-account)
-        account names.
-    Returns:
-      A tuple of entries and errors.
-
-    """
-
-    start_time = time.time()
-    errors = []
-
-    interesting_entries = []
-    filtered_entries = []
-    new_accounts = []
-    for entry in entries:
-        outlist = (interesting_entries
-                   if (isinstance(entry, data.Transaction) and
-                       'effective_date' in entry.meta and
-                       type(entry.meta['effective_date']) is datetime.date)
-                   else filtered_entries)
-        outlist.append(entry)
-
-    # print("------")
-    # for e in interesting_entries:
-    #     # print(e)
-    #     printer.print_entry(e)
-    #     print(type(e.meta.effective_date) is datetime.date)
-    #     print("")
-    # print("------")
-
-    modcount = 0
-    new_entries = []
-    for entry in interesting_entries:
-        modified_entry_postings = []
-        effective_date_entry_postings = []
-        found = False
-        accts_to_split = {
-                'Expenses': {'earlier': 'Liabilities:Hold', 'later': 'Assets:Hold'},
-                'Income':   {'earlier': 'Assets:Hold', 'later': 'Liabilities:Hold'},
-                }
-        for posting in entry.postings:
-            if any(acct in posting.account for acct in accts_to_split):
-                found_acct = ''
-                for acct in accts_to_split:
-                    if posting.account.startswith(acct):
-                        found_acct = acct
-                found = True
-                modcount += 1
-
-                holding_account = accts_to_split[found_acct]['earlier']
-                if entry.meta['effective_date'] > entry.date:
-                    holding_account = accts_to_split[found_acct]['later']
-                new_posting = posting._replace(account=posting.account.replace(found_acct, holding_account))
-                if new_posting.account not in new_accounts:
-                    new_accounts.append(new_posting.account)
-                modified_entry_postings += [new_posting]
-                effective_date_entry_postings += [posting]
-
-                effective_date_entry_postings += [posting._replace(
-                    account=posting.account.replace(found_acct, holding_account),
-                    units=-posting.units)]
-
-                if posting.account not in new_accounts:
-                    new_accounts.append(posting.account)
-
-            else:
-                modified_entry_postings += [posting]
-
-        if found:
-            rand_string = ''.join(random.choice(string.ascii_uppercase) for i in range(5))
-            link = LINK_FORMAT.format(rand_string)
-            # modified_entry = data.entry_replace(entry, postings=modified_entry_postings,
-            #                                     links=(entry.links or set()) | set([link]))
-            modified_entry = entry._replace(postings=modified_entry_postings,
-                                            links=(entry.links or set()) | set([link]))
-
-            effective_date_entry_narration = entry.narration + " (originally: {})".format(str(entry.date))
-            # effective_date_entry = data.entry_replace(entry, date=entry.meta['effective_date'],
-            #         postings=effective_date_entry_postings,
-            #         narration = effective_date_entry_narration,
-            #         links=(entry.links or set()) | set([link]))
-            new_meta = {'original_date': entry.date}
-            effective_date_entry = entry._replace(date=entry.meta['effective_date'],
-                                                  meta={**entry.meta, **new_meta},
-                                                  postings=effective_date_entry_postings,
-                                                  narration=effective_date_entry_narration,
-                                                  links=(entry.links or set()) | set([link]))
-            new_entries += [modified_entry, effective_date_entry]
-        else:
-            new_entries += [entry]
-
-    # print("Output results:")
-    # for e in new_entries:
-    #     printer.print_entry(e)
-
-    if DEBUG:
-        elapsed_time = time.time() - start_time
-        print("effective_date_transaction [{:.1f}s]: {} entries inserted.".format(elapsed_time, modcount))
-
-    new_open_entries = common.create_open_directives(new_accounts, entries, meta_desc='<effective_date>')
-    retval = new_open_entries + new_entries + filtered_entries
-    return retval, errors
 
 # TODO
 # -----------------------------------------------------------------------------------------------------------

--- a/beancount_reds_plugins/effective_date/examples.beancount
+++ b/beancount_reds_plugins/effective_date/examples.beancount
@@ -1,9 +1,12 @@
 option "operating_currency" "USD"
 
 plugin "beancount_reds_plugins.effective_date.effective_date" "{
+ 'holding_accts': {
  'Expenses': {'earlier': 'Liabilities:Hold:Expenses', 'later': 'Assets:Hold:Expenses'},
  'Income':   {'earlier': 'Assets:Hold:Income', 'later': 'Liabilities:Hold:Income'},
- }"
+  },
+  'link_zfill': 2,
+}"
 
 2012-01-01 open Assets:Bank
 2012-01-01 open Liabilities:Mastercard

--- a/beancount_reds_plugins/effective_date/legacy_effective_date_transaction.py
+++ b/beancount_reds_plugins/effective_date/legacy_effective_date_transaction.py
@@ -1,0 +1,165 @@
+"""Beancount plugin to implement per-posting effective dates. See README.md for more."""
+
+import datetime
+import random
+import string
+import time
+from beancount.core import data
+from beancount_reds_plugins.common import common
+
+DEBUG = 0
+
+# to enable this older transaction-level hacky plugin, edit __plugins__ in effective_date.py
+
+LINK_FORMAT = 'edate-{date}-{random}'
+
+
+def effective_date_transaction(entries, options_map, config):
+    """Effective dates
+
+    Changes this:
+
+    ------(
+    2014-02-01 "Estimated taxes for 2013"
+      effective_date: 2013-12-31
+      Liabilities:Mastercard    -2000 USD
+      Expenses:Taxes:Federal  2000 USD
+    )------
+
+    into this:
+    ------(
+    2014-02-01 "Estimated taxes for 2013"
+      Liabilities:Mastercard     -2000 USD
+      Liabilities:Hold:Taxes:Federal 2000 USD
+
+    2013-12-31 "Estimated taxes for 2013"
+      Liabilities:Hold:Taxes:Federal    -2000 USD
+      Expenses:Taxes:Federal    2000 USD
+    )------
+
+
+    # Example 2: realizing income earlier (eg: for taxes, accounting, etc.):
+    ------(
+    2017-01-03 "Paycheck"
+      effective_date: 2016-12-31
+      Income:Employment    -2000 USD
+      Assets:Bank  2000 USD
+    )------
+
+    into this:
+    ------(
+    2016-12-31 "Paycheck"
+      Income:Employment    -2000 USD
+      Assets:Hold:Income:Employment    2000 USD
+
+    2014-02-01 "Paycheck"
+      Assets:Hold:Income:Employment    -2000 USD
+      Assets:Bank  2000 USD
+    )------
+
+
+    Args:
+      entries: a list of entry instances
+      options_map: a dict of options parsed from the file
+      config: A configuration string, which is intended to be a Python dict
+        mapping match-accounts to a pair of (negative-account, position-account)
+        account names.
+    Returns:
+      A tuple of entries and errors.
+
+    """
+
+    start_time = time.time()
+    errors = []
+
+    interesting_entries = []
+    filtered_entries = []
+    new_accounts = []
+    for entry in entries:
+        outlist = (interesting_entries
+                   if (isinstance(entry, data.Transaction) and
+                       'effective_date' in entry.meta and
+                       type(entry.meta['effective_date']) is datetime.date)
+                   else filtered_entries)
+        outlist.append(entry)
+
+    # print("------")
+    # for e in interesting_entries:
+    #     # print(e)
+    #     printer.print_entry(e)
+    #     print(type(e.meta.effective_date) is datetime.date)
+    #     print("")
+    # print("------")
+
+    modcount = 0
+    new_entries = []
+    for entry in interesting_entries:
+        modified_entry_postings = []
+        effective_date_entry_postings = []
+        found = False
+        accts_to_split = {
+                'Expenses': {'earlier': 'Liabilities:Hold', 'later': 'Assets:Hold'},
+                'Income':   {'earlier': 'Assets:Hold', 'later': 'Liabilities:Hold'},
+                }
+        for posting in entry.postings:
+            if any(acct in posting.account for acct in accts_to_split):
+                found_acct = ''
+                for acct in accts_to_split:
+                    if posting.account.startswith(acct):
+                        found_acct = acct
+                found = True
+                modcount += 1
+
+                holding_account = accts_to_split[found_acct]['earlier']
+                if entry.meta['effective_date'] > entry.date:
+                    holding_account = accts_to_split[found_acct]['later']
+                new_posting = posting._replace(account=posting.account.replace(found_acct, holding_account))
+                if new_posting.account not in new_accounts:
+                    new_accounts.append(new_posting.account)
+                modified_entry_postings += [new_posting]
+                effective_date_entry_postings += [posting]
+
+                effective_date_entry_postings += [posting._replace(
+                    account=posting.account.replace(found_acct, holding_account),
+                    units=-posting.units)]
+
+                if posting.account not in new_accounts:
+                    new_accounts.append(posting.account)
+
+            else:
+                modified_entry_postings += [posting]
+
+        if found:
+            rand_string = ''.join(random.choice(string.ascii_uppercase) for i in range(5))
+            link = LINK_FORMAT.format(rand_string)
+            # modified_entry = data.entry_replace(entry, postings=modified_entry_postings,
+            #                                     links=(entry.links or set()) | set([link]))
+            modified_entry = entry._replace(postings=modified_entry_postings,
+                                            links=(entry.links or set()) | set([link]))
+
+            effective_date_entry_narration = entry.narration + " (originally: {})".format(str(entry.date))
+            # effective_date_entry = data.entry_replace(entry, date=entry.meta['effective_date'],
+            #         postings=effective_date_entry_postings,
+            #         narration = effective_date_entry_narration,
+            #         links=(entry.links or set()) | set([link]))
+            new_meta = {'original_date': entry.date}
+            effective_date_entry = entry._replace(date=entry.meta['effective_date'],
+                                                  meta={**entry.meta, **new_meta},
+                                                  postings=effective_date_entry_postings,
+                                                  narration=effective_date_entry_narration,
+                                                  links=(entry.links or set()) | set([link]))
+            new_entries += [modified_entry, effective_date_entry]
+        else:
+            new_entries += [entry]
+
+    # print("Output results:")
+    # for e in new_entries:
+    #     printer.print_entry(e)
+
+    if DEBUG:
+        elapsed_time = time.time() - start_time
+        print("effective_date_transaction [{:.1f}s]: {} entries inserted.".format(elapsed_time, modcount))
+
+    new_open_entries = common.create_open_directives(new_accounts, entries, meta_desc='<effective_date>')
+    retval = new_open_entries + new_entries + filtered_entries
+    return retval, errors

--- a/beancount_reds_plugins/zerosum/README.md
+++ b/beancount_reds_plugins/zerosum/README.md
@@ -191,7 +191,7 @@ the source accounts, making the config below equivalent to the config above:
 Optionally, the plugin can add transaction level or posting level links, tying together
 related transactions or postings. Transaction level links use Beancount's linking
 feature. Beancount does not support posting level links, and thus, these use metadata.
-Both use randomly generated link ids.
+Both use the same sequential link ids.
 
 To use these, see the following options documented at the top of `zerosum.py`:
 - 'match_metadata'


### PR DESCRIPTION
This commit addresses `effective_dates` and `zerosum`:

1. **Data Integrity** Eliminates link / metadata collisions, which are much more probable than intuition suggests due to the "birthday problem."
2. **UX** for new users by making the option syntax for `effective_dates` much closer to that of `zerosum`
3. **Code Simplicity/Consistency**:
3.1 Common functionality for link ID generation and configuration parsing has been moved into `common`
3.2 The legacy transaction-based version of `effective_dates` has been moved into a separate file.
****
The statistics suggest an overall change of +125 lines of code.  This includes:
-  3 lines added `.gitignore`
-  165 lines for the file containing the legacy transaction-based version of `effective dates`
- 57 lines of unit tests

Thus this change might be best characterized as a **100 line reduction** of active algorithmic code.
****
One additional observation: a small performance improvement could be obtained by inserting a `break` statement on [ L113 of `effective_dates.py`](https://github.com/loverobean/beancount_reds_plugins/blob/ea85b2061d27454e6fa2debcf31a4dd476653d1b/beancount_reds_plugins/effective_date/effective_date.py#L113).  This would cause the plugin to use the _first_ matching account, rather than the last.  Now that `hold_accounts` has its own dictionary key in the config, perhaps this change should be made at the same time.
****
:heart: Happy Valentine's Day :heart: 

