### PR TITLE
feat(zerosum): add match_metadata_details

### DIFF
--- a/beancount_reds_plugins/zerosum/test_zerosum.py
+++ b/beancount_reds_plugins/zerosum/test_zerosum.py
@@ -334,6 +334,114 @@ class TestUnrealized(unittest.TestCase):
         )
 
     @loader.load_doc()
+    def test_no_match_metadata_details_by_default(self, entries, _, options_map):
+        """
+        2015-01-01 open Liabilities:Credit-Cards:Green
+        2015-01-01 open Assets:Zero-Sum-Accounts:Returns-and-Temporary
+        2015-06-15 * "Expensive furniture"
+          Liabilities:Credit-Cards:Green  -2526.02 USD
+          Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
+          Assets:Zero-Sum-Accounts:Returns-and-Temporary             1263.01 USD
+
+        2015-06-23 * "Expensive furniture Refund"
+          Liabilities:Credit-Cards:Green  1263.01 USD
+          Assets:Zero-Sum-Accounts:Returns-and-Temporary
+
+        2015-06-23 * "Expensive furniture Refund"
+          Liabilities:Credit-Cards:Green  1263.01 USD
+          Assets:Zero-Sum-Accounts:Returns-and-Temporary
+        """
+        new_entries, _ = zerosum.zerosum(entries, options_map, config)
+
+        matched = get_entries_with_acc_regexp(new_entries, ":ZSA-Matched")
+
+        self.assertEqual(3, len(matched))
+        for m in matched:
+            for p in m.postings:
+                self.assertTrue("source_account" not in p.meta)
+                self.assertTrue("matched_account" not in p.meta)
+                self.assertTrue("matched_date" not in p.meta)
+
+    @loader.load_doc()
+    def test_match_metadata_details_added(self, entries, _, options_map):
+        """
+        2023-01-01 open Assets:Bank:Checking
+        2023-01-01 open Assets:Bank:Savings
+        2023-01-01 open Assets:Zero-Sum-Accounts:Checkings
+
+        2024-01-01 * "Transfer out"
+          Assets:Bank:Checking                          -500.00 USD
+          Assets:Zero-Sum-Accounts:Checkings             500.00 USD
+
+        2024-01-02 * "Transfer in"
+          Assets:Bank:Savings                            500.00 USD
+          Assets:Zero-Sum-Accounts:Checkings
+        """
+        new_entries, _ = zerosum.zerosum(
+            entries, options_map, config[:-2] + """'match_metadata_details': True,\n}"""
+        )
+
+        matched = dict(
+            [
+                (m.narration, m)
+                for m in get_entries_with_acc_regexp(new_entries, ":ZSA-Matched")
+            ]
+        )
+
+        self.assertEqual(2, len(matched))
+
+        # Transfer out posting: source=Assets:Bank:Checking, matched=Assets:Bank:Savings, date=2024-01-02
+        out_posting = matched["Transfer out"].postings[1]
+        self.assertEqual("Assets:Bank:Checking", out_posting.meta["source_account"])
+        self.assertEqual("Assets:Bank:Savings", out_posting.meta["matched_account"])
+        self.assertEqual("2024-01-02", out_posting.meta["matched_date"])
+
+        # Transfer in posting: source=Assets:Bank:Savings, matched=Assets:Bank:Checking, date=2024-01-01
+        in_posting = matched["Transfer in"].postings[1]
+        self.assertEqual("Assets:Bank:Savings", in_posting.meta["source_account"])
+        self.assertEqual("Assets:Bank:Checking", in_posting.meta["matched_account"])
+        self.assertEqual("2024-01-01", in_posting.meta["matched_date"])
+
+    @loader.load_doc()
+    def test_match_metadata_details_names_changed(self, entries, _, options_map):
+        """
+        2023-01-01 open Assets:Bank:Checking
+        2023-01-01 open Assets:Bank:Savings
+        2023-01-01 open Assets:Zero-Sum-Accounts:Checkings
+
+        2024-01-01 * "Transfer out"
+          Assets:Bank:Checking                          -500.00 USD
+          Assets:Zero-Sum-Accounts:Checkings             500.00 USD
+
+        2024-01-02 * "Transfer in"
+          Assets:Bank:Savings                            500.00 USD
+          Assets:Zero-Sum-Accounts:Checkings
+        """
+        new_entries, _ = zerosum.zerosum(
+            entries,
+            options_map,
+            config[:-2]
+            + """'match_metadata_details': True,\n'match_metadata_details_names': ('src', 'matched', 'date')\n}""",
+        )
+
+        matched = dict(
+            [
+                (m.narration, m)
+                for m in get_entries_with_acc_regexp(new_entries, ":ZSA-Matched")
+            ]
+        )
+
+        self.assertEqual(2, len(matched))
+
+        out_posting = matched["Transfer out"].postings[1]
+        self.assertIn("src", out_posting.meta)
+        self.assertIn("matched", out_posting.meta)
+        self.assertIn("date", out_posting.meta)
+        self.assertNotIn("source_account", out_posting.meta)
+        self.assertNotIn("matched_account", out_posting.meta)
+        self.assertNotIn("matched_date", out_posting.meta)
+
+    @loader.load_doc()
     def test_no_links_by_default(self, entries, _, options_map):
         """
         2015-01-01 open Liabilities:Credit-Cards:Green

--- a/beancount_reds_plugins/zerosum/zerosum.py
+++ b/beancount_reds_plugins/zerosum/zerosum.py
@@ -176,6 +176,8 @@ DEBUG = 0
 DEFAULT_TOLERANCE = 0.0099
 MATCHING_ID_STRING = "match_id"
 LINK_PREFIX = "ZeroSum."
+MATCH_METADATA_DETAILS_NAMES = ("source_account", "matched_account", "matched_date")
+MATCH_METADATA_DETAILS_ACCOUNT_TYPES = ("Assets", "Liabilities")
 random.seed(6)  # arbitrary fixed seed
 
 __plugins__ = (
@@ -205,6 +207,29 @@ def metadata_update(txn, posting, match_id, matching_id_string):
 def transaction_update(txn, match_id, link_prefix):
     if match_id and link_prefix:
         txn.links.add(link_prefix + match_id)
+
+
+def get_counterpart_account(txn, zs_accounts_list, account_types):
+    """Return the first posting account (with units) matching account_types that is not a zerosum account (typically an Assets/Liabilities account)."""
+    for p in txn.postings:
+        if (
+            p.account not in zs_accounts_list
+            and p.units
+            and any(p.account.startswith(t) for t in account_types)
+        ):
+            return p.account
+    return None
+
+
+def metadata_update_details(posting, source_acc, matched_acc, matched_dt, key_names):
+    if source_acc and matched_acc and posting.meta is not None:
+        posting.meta.update(
+            {
+                key_names[0]: source_acc,
+                key_names[1]: matched_acc,
+                key_names[2]: str(matched_dt),
+            }
+        )
 
 
 def zerosum(entries, options_map, config):  # noqa: C901
@@ -239,6 +264,16 @@ def zerosum(entries, options_map, config):  # noqa: C901
         have links added, allowing manual verification in post (default off)
 
       - 'link_prefix': prefix to use in link names (default 'ZeroSum.')
+
+      - 'match_metadata_details': bool to add source/matched account and date metadata to
+        matched postings (default off)
+
+      - 'match_metadata_details_names': tuple of three strings overriding the metadata key
+        names for (source_account, matched_account, matched_date)
+        (default ('source_account', 'matched_account', 'matched_date'))
+
+      - 'match_metadata_details_account_types': tuple of account type prefixes used to
+        identify the counterpart account in each transaction (default ('Assets', 'Liabilities'))
 
       See example for more info.
 
@@ -285,6 +320,13 @@ def zerosum(entries, options_map, config):  # noqa: C901
     match_metadata_name = config_obj.pop("match_metadata_name", MATCHING_ID_STRING)
     link_transactions = config_obj.pop("link_transactions", False)
     link_prefix = config_obj.pop("link_prefix", LINK_PREFIX)
+    match_metadata_details = config_obj.pop("match_metadata_details", False)
+    match_metadata_details_names = config_obj.pop(
+        "match_metadata_details_names", MATCH_METADATA_DETAILS_NAMES
+    )
+    match_metadata_details_account_types = config_obj.pop(
+        "match_metadata_details_account_types", MATCH_METADATA_DETAILS_ACCOUNT_TYPES
+    )
 
     new_accounts = set()
     zerosum_postings_count = 0
@@ -344,6 +386,32 @@ def zerosum(entries, options_map, config):  # noqa: C901
                             if link_transactions:
                                 transaction_update(txn, match_id, link_prefix)
                                 transaction_update(match[1], match_id, link_prefix)
+
+                            if match_metadata_details:
+                                src_acc = get_counterpart_account(
+                                    txn,
+                                    zs_accounts_list,
+                                    match_metadata_details_account_types,
+                                )
+                                match_src_acc = get_counterpart_account(
+                                    match[1],
+                                    zs_accounts_list,
+                                    match_metadata_details_account_types,
+                                )
+                                metadata_update_details(
+                                    posting,
+                                    src_acc,
+                                    match_src_acc,
+                                    match[1].date,
+                                    match_metadata_details_names,
+                                )
+                                metadata_update_details(
+                                    match[0],
+                                    match_src_acc,
+                                    src_acc,
+                                    txn.date,
+                                    match_metadata_details_names,
+                                )
 
                             new_accounts.add(target_account)
                             reprocess = True


### PR DESCRIPTION
To resolve [this issue](https://github.com/redstreet/beancount_reds_plugins/issues/48), add `match_metadata_details`, controlled through up to 3 new config keys.

Clauded, but reviewed. Follows existing code patterns in the repo. Tested in unit tests and with my personal ledger.